### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/src/utils/http.dart
+++ b/lib/src/utils/http.dart
@@ -8,7 +8,7 @@ Future<String> fetch(String url) async {
   if (response.statusCode != 200) {
     throw new Exception("Failed to fetch ${url}");
   }
-  return response.transform(UTF8.decoder).join().then((out) {
+  return UTF8.decoder.bind(response).join().then((out) {
     client.close();
     return out;
   });


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
